### PR TITLE
Infix notation of pow function

### DIFF
--- a/physo/physym/execute.py
+++ b/physo/physym/execute.py
@@ -110,7 +110,10 @@ def ComputeInfixNotation (program_tokens):
             else:
                 res = "%s(%s)" % (token.sympy_repr, args[0])
         elif token.arity == 2:
-            res = "(%s%s%s)" % (args[0], token.sympy_repr, args[1])
+            if token.sympy_repr == "pow":
+                res = "((%s)**(%s))" % (args[0], args[1])
+            else:
+                res = "(%s%s%s)" % (args[0], token.sympy_repr, args[1])
         elif token.arity > 2 :
             args_str = ""
             for arg in args: args_str+="%s,"%arg

--- a/physo/physym/tests/execute_UnitTest.py
+++ b/physo/physym/tests/execute_UnitTest.py
@@ -169,10 +169,10 @@ class ExecuteProgramTest(unittest.TestCase):
                         "constants_complexity" : {"pi" : 0.        , "c" : 0.        , "M" : 1.        , "1" : 1.        },
                             }
         my_lib = Lib.Library(args_make_tokens = args_make_tokens,
-                             superparent_units = [1, -2, 1], superparent_name = "y")
+                             superparent_units = [2, -2, 1], superparent_name = "y")
 
         # TEST PROGRAM
-        test_program_str = ["mul", "mul", "pow", "M", "pi", "n2", "c", "sub", "inv", "sqrt", "sub", "1", "div", "n2", "v", "n2",
+        test_program_str = ["mul", "mul", "M", "n2", "c", "sub", "inv", "sqrt", "sub", "pow", "1", "pi", "div", "n2", "v", "n2",
                             "c", "cos", "div", "sub", "1", "div", "v", "c", "pi"]
         test_program     = np.array([my_lib.lib_name_to_token[tok_str] for tok_str in test_program_str])
         # Infix output
@@ -184,9 +184,9 @@ class ExecuteProgramTest(unittest.TestCase):
         print("\nComputeInfixNotation time = %.3f ms"%((t1-t0)*1e3/N))
         infix = sympy.parsing.sympy_parser.parse_expr(infix_str)
         # Expected infix output
-        expected_str = "M**pi*(c**2.)*(1./((1.-(v**2)/(c**2))**0.5)-cos((1.-(v/c))/pi))"
+        expected_str = "M*(c**2.)*(1./((1.**pi-(v**2)/(c**2))**0.5)-cos((1.-(v/c))/pi))"
         expected = sympy.parsing.sympy_parser.parse_expr(expected_str)
-        # difference
+        # Difference
         diff = sympy.simplify(infix - expected, rational = True)
         works_bool = diff == 0
         self.assertTrue(works_bool)

--- a/physo/physym/tests/execute_UnitTest.py
+++ b/physo/physym/tests/execute_UnitTest.py
@@ -172,7 +172,7 @@ class ExecuteProgramTest(unittest.TestCase):
                              superparent_units = [1, -2, 1], superparent_name = "y")
 
         # TEST PROGRAM
-        test_program_str = ["mul", "mul", "M", "n2", "c", "sub", "inv", "sqrt", "sub", "1", "div", "n2", "v", "n2",
+        test_program_str = ["mul", "mul", "pow", "M", "pi", "n2", "c", "sub", "inv", "sqrt", "sub", "1", "div", "n2", "v", "n2",
                             "c", "cos", "div", "sub", "1", "div", "v", "c", "pi"]
         test_program     = np.array([my_lib.lib_name_to_token[tok_str] for tok_str in test_program_str])
         # Infix output
@@ -184,12 +184,13 @@ class ExecuteProgramTest(unittest.TestCase):
         print("\nComputeInfixNotation time = %.3f ms"%((t1-t0)*1e3/N))
         infix = sympy.parsing.sympy_parser.parse_expr(infix_str)
         # Expected infix output
-        expected_str = "M*(c**2.)*(1./((1.-(v**2)/(c**2))**0.5)-cos((1.-(v/c))/pi))"
+        expected_str = "M**pi*(c**2.)*(1./((1.-(v**2)/(c**2))**0.5)-cos((1.-(v/c))/pi))"
         expected = sympy.parsing.sympy_parser.parse_expr(expected_str)
         # difference
         diff = sympy.simplify(infix - expected, rational = True)
         works_bool = diff == 0
         self.assertTrue(works_bool)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
This pull request resolves a minor issue with the infix notation for the `pow` function, which was affecting the ability to save Pareto figures and print status whenever `pow` was part of the expression. The fix corrects the infix conversion process for the `pow` function.

Additionally, I've extended the infix test to cover the `pow` function (a test that would fail without the fix).