### PR TITLE
Fix free constant init value handling for documented dict inputs

### DIFF
--- a/physo/task/args_handler.py
+++ b/physo/task/args_handler.py
@@ -163,9 +163,19 @@ def check_library_args(
     # --- class_free_consts_init_val ---
     if class_free_consts_init_val is None:
         class_free_consts_init_val = np.ones(n_class_free_consts)
-    class_free_consts_init_val = np.array(class_free_consts_init_val).astype(float)
-    assert class_free_consts_init_val.shape[0] == n_class_free_consts, \
-        "There should be one class free constant initial value per free constant in class_free_consts_names"
+    if isinstance(class_free_consts_init_val, dict):
+        class_free_consts_init_val = {
+            class_free_consts_names[i]: float(class_free_consts_init_val[class_free_consts_names[i]])
+            for i in range(n_class_free_consts)
+        }
+    else:
+        class_free_consts_init_val = np.array(class_free_consts_init_val).astype(float)
+        assert class_free_consts_init_val.shape[0] == n_class_free_consts, \
+            "There should be one class free constant initial value per free constant in class_free_consts_names"
+        class_free_consts_init_val = {
+            class_free_consts_names[i]: class_free_consts_init_val[i]
+            for i in range(n_class_free_consts)
+        }
 
     # --- n_spe_free_consts ---
     if spe_free_consts_names is not None:
@@ -200,9 +210,19 @@ def check_library_args(
     # --- spe_free_consts_init_val ---
     if spe_free_consts_init_val is None:
         spe_free_consts_init_val = np.ones(n_spe_free_consts)
-    # Do not convert to array as user may use a mix of single floats and (n_realizations,) arrays
+    # Do not convert the whole input to one array as user may use a mix of single floats and (n_realizations,) arrays
     assert len(spe_free_consts_init_val) == n_spe_free_consts, \
         "There should be one spe free constant initial value per free constant in spe_free_consts_names"
+    if isinstance(spe_free_consts_init_val, dict):
+        spe_free_consts_init_val = {
+            spe_free_consts_names[i]: np.asarray(spe_free_consts_init_val[spe_free_consts_names[i]], dtype=float)
+            for i in range(n_spe_free_consts)
+        }
+    else:
+        spe_free_consts_init_val = {
+            spe_free_consts_names[i]: np.asarray(spe_free_consts_init_val[i], dtype=float)
+            for i in range(n_spe_free_consts)
+        }
 
     # --- op_names ---
     if op_names is None:
@@ -227,11 +247,11 @@ def check_library_args(
                     # class_free_constants
                     "class_free_constants"          : {class_free_consts_names[i]                                 for i in range(n_class_free_consts)},
                     "class_free_constants_units"    : {class_free_consts_names[i] : class_free_consts_units   [i] for i in range(n_class_free_consts)},
-                    "class_free_constants_init_val" : {class_free_consts_names[i] : class_free_consts_init_val[i] for i in range(n_class_free_consts)},
+                    "class_free_constants_init_val" : class_free_consts_init_val,
                     # spe_free_constants
                     "spe_free_constants"          : {spe_free_consts_names[i]                               for i in range(n_spe_free_consts)},
                     "spe_free_constants_units"    : {spe_free_consts_names[i] : spe_free_consts_units   [i] for i in range(n_spe_free_consts)},
-                    "spe_free_constants_init_val" : {spe_free_consts_names[i] : spe_free_consts_init_val[i] for i in range(n_spe_free_consts)},
+                    "spe_free_constants_init_val" : spe_free_consts_init_val,
                         }
 
     library_config = {"args_make_tokens"  : args_make_tokens,

--- a/physo/task/tests/args_handler_UnitTest.py
+++ b/physo/task/tests/args_handler_UnitTest.py
@@ -1,0 +1,166 @@
+import unittest
+
+import numpy as np
+
+import physo.task.args_handler as args_handler
+from physo.physym.free_const import FreeConstantsTable
+from physo.toolkit import codec
+
+
+class ArgsHandlerTest(unittest.TestCase):
+
+    def get_args_make_tokens(self, class_free_consts_init_val=None, spe_free_consts_init_val=None):
+        library_config = args_handler.check_library_args(
+            # X
+            X_names=["x"],
+            X_units=[[0, 0, 0]],
+            # y
+            y_name="y",
+            y_units=[0, 0, 0],
+            # Fixed constants
+            fixed_consts=[],
+            fixed_consts_units=[],
+            # Class free constants
+            class_free_consts_names=["c0", "c1"],
+            class_free_consts_units=[[0, 0, 0], [0, 0, 0]],
+            class_free_consts_init_val=class_free_consts_init_val,
+            # Spe Free constants
+            spe_free_consts_names=["k0", "k1"],
+            spe_free_consts_units=[[0, 0, 0], [0, 0, 0]],
+            spe_free_consts_init_val=spe_free_consts_init_val,
+            # Operations to use
+            op_names=["add"],
+            use_protected_ops=True,
+            # Number of realizations
+            n_realizations=3,
+            # Warn about units
+            warn_about_units=False,
+        )
+        return library_config["args_make_tokens"]
+
+    def assert_class_init_vals_equal(self, actual, expected):
+        self.assertEqual(set(actual.keys()), set(expected.keys()))
+        for name, value in expected.items():
+            self.assertAlmostEqual(actual[name], value)
+
+    def assert_spe_init_vals_equal(self, actual, expected):
+        self.assertEqual(set(actual.keys()), set(expected.keys()))
+        for name, value in expected.items():
+            np.testing.assert_array_equal(actual[name], np.asarray(value, dtype=float))
+
+    def test_class_free_consts_init_val_none(self):
+        args_make_tokens = self.get_args_make_tokens(class_free_consts_init_val=None)
+
+        self.assert_class_init_vals_equal(
+            args_make_tokens["class_free_constants_init_val"],
+            {"c0": 1.0, "c1": 1.0},
+        )
+
+    def test_class_free_consts_init_val_sequence_scalars(self):
+        args_make_tokens = self.get_args_make_tokens(class_free_consts_init_val=[1.0, 2.0])
+
+        self.assert_class_init_vals_equal(
+            args_make_tokens["class_free_constants_init_val"],
+            {"c0": 1.0, "c1": 2.0},
+        )
+
+    def test_class_free_consts_init_val_dict_scalars(self):
+        args_make_tokens = self.get_args_make_tokens(class_free_consts_init_val={"c0": 1.0, "c1": 2.0})
+
+        self.assert_class_init_vals_equal(
+            args_make_tokens["class_free_constants_init_val"],
+            {"c0": 1.0, "c1": 2.0},
+        )
+
+    def test_spe_free_consts_init_val_none(self):
+        args_make_tokens = self.get_args_make_tokens(spe_free_consts_init_val=None)
+
+        self.assert_spe_init_vals_equal(
+            args_make_tokens["spe_free_constants_init_val"],
+            {"k0": 1.0, "k1": 1.0},
+        )
+
+    def test_spe_free_consts_init_val_sequence_scalars(self):
+        args_make_tokens = self.get_args_make_tokens(spe_free_consts_init_val=[1.0, 2.0])
+
+        self.assert_spe_init_vals_equal(
+            args_make_tokens["spe_free_constants_init_val"],
+            {"k0": 1.0, "k1": 2.0},
+        )
+
+    def test_spe_free_consts_init_val_sequence_arrays(self):
+        args_make_tokens = self.get_args_make_tokens(
+            spe_free_consts_init_val=[
+                np.array([1.0, 1.1, 1.2]),
+                np.array([2.0, 2.1, 2.2]),
+            ],
+        )
+
+        self.assert_spe_init_vals_equal(
+            args_make_tokens["spe_free_constants_init_val"],
+            {
+                "k0": np.array([1.0, 1.1, 1.2]),
+                "k1": np.array([2.0, 2.1, 2.2]),
+            },
+        )
+
+    def test_spe_free_consts_init_val_dict_scalars(self):
+        args_make_tokens = self.get_args_make_tokens(spe_free_consts_init_val={"k0": 1.0, "k1": 2.0})
+
+        self.assert_spe_init_vals_equal(
+            args_make_tokens["spe_free_constants_init_val"],
+            {"k0": 1.0, "k1": 2.0},
+        )
+
+    def test_spe_free_consts_init_val_dict_arrays(self):
+        args_make_tokens = self.get_args_make_tokens(
+            spe_free_consts_init_val={
+                "k0": np.array([1.0, 1.1, 1.2]),
+                "k1": np.array([2.0, 2.1, 2.2]),
+            },
+        )
+
+        self.assert_spe_init_vals_equal(
+            args_make_tokens["spe_free_constants_init_val"],
+            {
+                "k0": np.array([1.0, 1.1, 1.2]),
+                "k1": np.array([2.0, 2.1, 2.2]),
+            },
+        )
+
+    def test_dict_init_vals_build_free_constants_table(self):
+        lib = codec.get_library(
+            # X
+            X_names=["x"],
+            X_units=[[0, 0, 0]],
+            # y
+            y_name="y",
+            y_units=[0, 0, 0],
+            # Fixed constants
+            fixed_consts=[],
+            fixed_consts_units=[],
+            # Class free constants
+            free_consts_names=["c0"],
+            free_consts_units=[[0, 0, 0]],
+            free_consts_init_val={"c0": 3.0},
+            # Spe Free constants
+            spe_free_consts_names=["k0", "k1"],
+            spe_free_consts_units=[[0, 0, 0], [0, 0, 0]],
+            spe_free_consts_init_val={"k0": np.array([1.0, 1.1, 1.2]), "k1": 2.0},
+            # Operations to use
+            op_names=["add"],
+            # Number of realizations
+            n_realizations=3,
+        )
+
+        FreeConstantsTable(batch_size=1, library=lib, n_realizations=3)
+
+        np.testing.assert_array_equal(lib.class_free_constants_init_val, np.array([3.0]))
+        np.testing.assert_array_equal(
+            lib.spe_free_constants_init_val,
+            np.array([[1.0, 1.1, 1.2], [2.0, 2.0, 2.0]]),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  Hi Wassim, I opened this PR to fix a small mismatch between the documented API and the
  way free constant initial values were handled internally.

  `ClassSR` documents `spe_free_consts_init_val` as accepting a
  dictionary keyed by the SPE free constant name, eg. `{"k0":
  1.0, "k1": [1.0, 1.1, 1.2]}`.

  But in `check_library_args`, that value was still being treated like
  an ordered sequence. So passing the documented dict form would try
  to access `spe_free_consts_init_val[0]`, which raises `KeyError: 0`.

  The fix is to normalize the input once, before `args_make_tokens` is
  built. After normalization, both supported forms end up as the same
  name-keyed dictionary internally: `[1.0, 2.0]` and `{"k0": 1.0,
  "k1": 2.0}` both become `{"k0": 1.0, "k1": 2.0}`.

  I also applied the same normalization to
  `class_free_consts_init_val`, since that argument is documented as
  accepting dict input as well and had the same kind of mismatch.

  ## Tests

  I added some focused tests for:

  - `spe_free_consts_init_val=None`
  - ordered SPE scalar values
  - ordered SPE per-realization arrays
  - SPE dict scalar values
  - SPE dict per-realization arrays
  - class free constant `None`, sequence, and dict inputs
  - construction through `codec.get_library` and `FreeConstantsTable`

  I ran `MPLCONFIGDIR=/private/tmp python -m unittest
  physo.task.tests.args_handler_UnitTest` and `MPLCONFIGDIR=/private/
  tmp python -m unittest physo.toolkit.tests.codec_UnitTest`.

  Both pass 